### PR TITLE
Fix VersionEdit::SplitEdit

### DIFF
--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -286,10 +286,10 @@ Status VersionEdit::SplitEdit(InternalKey& ikey,
   while (it != new_files_.end()) {
     FileMetaData& f = it->second;
     if (direct == SPLIT_LEFT) {
-      if (icmp.Compare(ikey, f.smallest) < 0) {
+      if (icmp.Compare(ikey, f.smallest) <= 0) {
         it = new_files_.erase(it);
         continue;
-      } else if (icmp.Compare(f.largest, ikey) >= 0) {
+      } else if (icmp.Compare(f.largest, ikey) > 0) {
         f.largest = ikey;
       }
     } else {


### PR DESCRIPTION
当splitkey等于smallest时，可以在left中将这个文件删除。
其实从下面对于right的处理也可以看出，对于left的处理应该是对称的。
